### PR TITLE
Small Changes

### DIFF
--- a/addons/csv-data-importer/csv_data.gd
+++ b/addons/csv-data-importer/csv_data.gd
@@ -17,15 +17,15 @@ var data:
 	get:
 		return _data
 
-func _init(auto_setup = true):
+func _init(auto_setup = false):
 	_auto_setup = auto_setup
 
 
 func setup():
-    if _initialed:
-        push_warn(">_< csv file already setuped !")
-        return self
-    _initialed = true
+	if _initialed:
+		push_warning(">_< csv file already setuped !")
+		return self
+	_initialed = true
 	var field_indexs = {}
 	for i in range(headers.size()):
 		field_indexs[headers[i]] = i

--- a/addons/csv-data-importer/import_plugin.gd
+++ b/addons/csv-data-importer/import_plugin.gd
@@ -80,14 +80,18 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var meta = _parse_headers(file, options,delim)
 	while not file.eof_reached():
 		var line = file.get_csv_line(delim)
+		
 		var row = _parse_typed(line, meta.headers, meta.field_types)
 		if row==null or not row.size():
+			push_warning("[csv-importer]:csv row data null ",line)
 			continue
 		lines.append_row(row)
+		
 	file.close()
+	
 	# do not setup here
-	var data = preload("csv_data.gd").new()
-	var rows = lines.get_data()
+	var data = preload("csv_data.gd").new(false)
+	var rows = lines.get_data() 
 	data.records = rows
 	data.headers = meta.headers
 
@@ -123,7 +127,7 @@ func _parse_headers(f: FileAccess, options,delim):
 func _parse_typed(csv_row: PackedStringArray, headers:PackedStringArray, types):
 	var column = headers.size()
 	if csv_row.size() != column:
-		push_warning("[csv-importer]:csv row data not enough ",csv_row)
+		push_warning("[csv-importer]:csv row data not enough ",column," - > ",csv_row.size()," = ",csv_row)
 		return []
 	var row = []
 	for i in range(headers.size()):

--- a/addons/csv-data-importer/import_plugin.gd
+++ b/addons/csv-data-importer/import_plugin.gd
@@ -77,7 +77,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	var lines := Array2D.new()
 
-	var meta = _parse_headers(file, options)
+	var meta = _parse_headers(file, options,delim)
 	while not file.eof_reached():
 		var line = file.get_csv_line(delim)
 		var row = _parse_typed(line, meta.headers, meta.field_types)
@@ -86,7 +86,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		lines.append_row(row)
 	file.close()
 	# do not setup here
-	var data = preload("csv_data.gd").new(false)
+	var data = preload("csv_data.gd").new()
 	var rows = lines.get_data()
 	data.records = rows
 	data.headers = meta.headers
@@ -98,13 +98,13 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	return err
 
 
-func _parse_headers(f: FileAccess, options):
+func _parse_headers(f: FileAccess, options,delim):
 	var model_name = ""
 	if options.describe_headers:
-		var _desc = f.get_csv_line()
+		var _desc = f.get_csv_line(delim)
 		model_name= _desc[0]
-	var headers = f.get_csv_line()
-	var types = f.get_csv_line()
+	var headers = f.get_csv_line(delim)
+	var types = f.get_csv_line(delim)
 	#
 	var field_indexs = {}
 	var field_types = {}
@@ -153,6 +153,7 @@ func _parse_typed_value(p_value: String, p_type: String):
 		"json":
 			if p_value.is_empty():
 				p_value = "[]"
+			p_value = p_value.replace("`", "\"")
 			return str_to_var(p_value)
 		_:
 			push_error("can not parse type ", p_type)


### PR DESCRIPTION
_parse_headers did not use delim
var data = preload("csv_data.gd").new(false) did not work on 4.2
changes to 
var data = preload("csv_data.gd").new()

" worked strange in json so support for ` to "
p_value = p_value.replace("`", "\"")
